### PR TITLE
Order Form Fix

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {

--- a/application/src/private.js
+++ b/application/src/private.js
@@ -1,3 +1,3 @@
 const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
 
-export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://192.168.99.100:4000';
+export const SERVER_IP = windowsPlatforms.indexOf(window.navigator.platform) < 0 ? 'http://localhost:4000' : 'http://127.0.0.1:4000';


### PR DESCRIPTION
in orderForm.js, "item" should be spelled as "order_item" to match the Order Models requirements